### PR TITLE
[System Pop Up] Add GitHub Action for release webhook notifications

### DIFF
--- a/.github/workflows/release-webhook.yml
+++ b/.github/workflows/release-webhook.yml
@@ -1,0 +1,125 @@
+name: Release Webhook Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send webhook notification
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_GITHUB_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.RELEASE_GITHUB_WEBHOOK_SECRET }}
+        run: |
+          # Create the webhook payload matching the expected GitHub release webhook format
+          payload=$(cat << EOF
+          {
+            "action": "${{ github.event.action }}",
+            "release": {
+              "tag_name": "${{ github.event.release.tag_name }}",
+              "name": ${{ toJSON(github.event.release.name) }},
+              "body": ${{ toJSON(github.event.release.body) }},
+              "draft": ${{ github.event.release.draft }},
+              "prerelease": ${{ github.event.release.prerelease }},
+              "created_at": "${{ github.event.release.created_at }}",
+              "published_at": "${{ github.event.release.published_at }}",
+              "tarball_url": "${{ github.event.release.tarball_url }}",
+              "zipball_url": "${{ github.event.release.zipball_url }}",
+              "html_url": "${{ github.event.release.html_url }}",
+              "id": ${{ github.event.release.id }},
+              "node_id": "${{ github.event.release.node_id }}",
+              "url": "${{ github.event.release.url }}",
+              "target_commitish": "${{ github.event.release.target_commitish }}",
+              "author": {
+                "login": "${{ github.event.release.author.login }}",
+                "id": ${{ github.event.release.author.id }},
+                "node_id": "${{ github.event.release.author.node_id }}",
+                "avatar_url": "${{ github.event.release.author.avatar_url }}",
+                "html_url": "${{ github.event.release.author.html_url }}",
+                "url": "${{ github.event.release.author.url }}",
+                "type": "${{ github.event.release.author.type }}",
+                "site_admin": ${{ github.event.release.author.site_admin }}
+              }
+            },
+            "repository": {
+              "name": "${{ github.event.repository.name }}",
+              "full_name": "${{ github.event.repository.full_name }}",
+              "html_url": "${{ github.event.repository.html_url }}",
+              "clone_url": "${{ github.event.repository.clone_url }}",
+              "id": ${{ github.event.repository.id }},
+              "node_id": "${{ github.event.repository.node_id }}",
+              "created_at": "${{ github.event.repository.created_at }}",
+              "updated_at": "${{ github.event.repository.updated_at }}",
+              "pushed_at": "${{ github.event.repository.pushed_at }}",
+              "default_branch": "${{ github.event.repository.default_branch }}",
+              "private": ${{ github.event.repository.private }},
+              "fork": ${{ github.event.repository.fork }},
+              "git_url": "${{ github.event.repository.git_url }}",
+              "ssh_url": "${{ github.event.repository.ssh_url }}",
+              "url": "${{ github.event.repository.url }}",
+              "owner": {
+                "login": "${{ github.event.repository.owner.login }}",
+                "id": ${{ github.event.repository.owner.id }},
+                "node_id": "${{ github.event.repository.owner.node_id }}",
+                "avatar_url": "${{ github.event.repository.owner.avatar_url }}",
+                "html_url": "${{ github.event.repository.owner.html_url }}",
+                "url": "${{ github.event.repository.owner.url }}",
+                "type": "${{ github.event.repository.owner.type }}",
+                "site_admin": ${{ github.event.repository.owner.site_admin }}
+              }
+            },
+            "sender": {
+              "login": "${{ github.event.sender.login }}",
+              "id": ${{ github.event.sender.id }},
+              "node_id": "${{ github.event.sender.node_id }}",
+              "avatar_url": "${{ github.event.sender.avatar_url }}",
+              "html_url": "${{ github.event.sender.html_url }}",
+              "url": "${{ github.event.sender.url }}",
+              "type": "${{ github.event.sender.type }}",
+              "site_admin": ${{ github.event.sender.site_admin }}
+            }
+          }
+          EOF
+          )
+
+          # Generate GitHub webhook signature using HMAC-SHA256
+          signature=$(echo -n "$payload" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -hex | cut -d' ' -f2)
+          
+          # Send the webhook request
+          echo "Sending webhook to: $WEBHOOK_URL"
+          echo "Release: ${{ github.event.release.tag_name }}"
+          echo "Action: ${{ github.event.action }}"
+          
+          response=$(curl -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Hookshot/comfyui-release" \
+            -H "X-Hub-Signature-256: sha256=$signature" \
+            -d "$payload" \
+            "$WEBHOOK_URL")
+          
+          http_code="${response: -3}"
+          response_body="${response%???}"
+          
+          echo "HTTP Status: $http_code"
+          echo "Response: $response_body"
+          
+          if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+            echo "✅ Webhook sent successfully"
+          else
+            echo "❌ Webhook failed with status $http_code"
+            echo "Response body: $response_body"
+            exit 1
+          fi
+
+      - name: Log release info
+        run: |
+          echo "Release details:"
+          echo "  Tag: ${{ github.event.release.tag_name }}"
+          echo "  Name: ${{ github.event.release.name }}"
+          echo "  Draft: ${{ github.event.release.draft }}"
+          echo "  Prerelease: ${{ github.event.release.prerelease }}"
+          echo "  Action: ${{ github.event.action }}"
+          echo "  Repository: ${{ github.event.repository.full_name }}" 


### PR DESCRIPTION
## Summary
Adds a new GitHub Action workflow that automatically calls the comfy-api webhook endpoint when releases are published.

## Changes
- **Added** `release-webhook.yml` workflow
- **Triggers** on release `published` events
- **Calls** `POST /releases` endpoint in comfy-api
- **Includes** proper HMAC-SHA256 signature verification for security

## Configuration Required
- `RELEASE_GITHUB_WEBHOOK_URL` - Webhook endpoint URL
- `RELEASE_GITHUB_WEBHOOK_SECRET` - Secret for signature verification

This enables automated release note processing and other downstream release workflows.