### PR TITLE
[System Pop Up] Add GitHub Action for release webhook notifications

### DIFF
--- a/.github/workflows/release-webhook.yml
+++ b/.github/workflows/release-webhook.yml
@@ -96,6 +96,7 @@ jobs:
             -X POST \
             -H "Content-Type: application/json" \
             -H "User-Agent: GitHub-Hookshot/comfyui-release" \
+            -H "X-GitHub-Event: release" \
             -H "X-Hub-Signature-256: sha256=$signature" \
             -d "$payload" \
             "$WEBHOOK_URL")


### PR DESCRIPTION
## Summary
Adds a new GitHub Action workflow that automatically calls the comfy-api webhook endpoint when releases are published.

## Changes
- **Added** `release-webhook.yml` workflow
- **Triggers** on release `published` events
- **Calls** `POST /releases` endpoint in comfy-api
- **Includes** proper HMAC-SHA256 signature verification for security

## Configuration Required
- `RELEASE_GITHUB_WEBHOOK_URL` - Webhook endpoint URL
- `RELEASE_GITHUB_WEBHOOK_SECRET` - Secret for signature verification

This enables automated release note processing and other downstream release workflows.